### PR TITLE
Added `_` to `Node` and `Field` protocol properties

### DIFF
--- a/Sources/SwiftSysctl/Extension/Sysctl+.swift
+++ b/Sources/SwiftSysctl/Extension/Sysctl+.swift
@@ -15,7 +15,7 @@ extension Sysctl {
     ///
     /// https://github.com/apple-oss-distributions/xnu/blob/94d3b452840153a99b38a3a9659680b2a006908e/bsd/kern/kern_newsysctl.c#L781
     public static func _name(_ oid: [Int32]) -> String? {
-        let field = SwiftSysctl.sysctl._name
+        let field = SwiftSysctl.sysctl.name
         return sysctl(field, additional: oid)?.withUnsafeBytes {
             guard let baseAddress = $0.baseAddress else {
                 return nil

--- a/Sources/SwiftSysctl/Node/Nodes+Sysctl.swift
+++ b/Sources/SwiftSysctl/Node/Nodes+Sysctl.swift
@@ -16,7 +16,7 @@ extension Nodes {
             oid: OID.Sysctl.debug
         )
 
-        public let _name = AnyNode(
+        public let name = AnyNode(
             oid: OID.Sysctl.name
         )
 

--- a/Sources/SwiftSysctl/Node/Nodes.swift
+++ b/Sources/SwiftSysctl/Node/Nodes.swift
@@ -14,10 +14,10 @@ public enum Nodes {}
 public struct SysctlNode: TopNodeProtocol {
     public typealias Child = Nodes.Sysctl
 
-    public let oid = OID.TopLevel.sysctl
+    public let _oid = OID.TopLevel.sysctl
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
     }
 }
 
@@ -25,10 +25,10 @@ public struct SysctlNode: TopNodeProtocol {
 public struct KernNode: TopNodeProtocol {
     public typealias Child = Nodes.Kern
 
-    public let oid = OID.TopLevel.kern
+    public let _oid = OID.TopLevel.kern
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
     }
 }
 
@@ -36,10 +36,10 @@ public struct KernNode: TopNodeProtocol {
 public struct VMNode: TopNodeProtocol {
     public typealias Child = Nodes.VM
 
-    public let oid = OID.TopLevel.vm
+    public let _oid = OID.TopLevel.vm
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
     }
 }
 
@@ -47,10 +47,10 @@ public struct VMNode: TopNodeProtocol {
 public struct VFSNode: TopNodeProtocol {
     public typealias Child = Nodes.VFS
 
-    public let oid = OID.TopLevel.vfs
+    public let _oid = OID.TopLevel.vfs
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
     }
 }
 
@@ -58,10 +58,10 @@ public struct VFSNode: TopNodeProtocol {
 public struct NetNode: TopNodeProtocol {
     public typealias Child = Nodes.Net
 
-    public let oid = OID.TopLevel.net
+    public let _oid = OID.TopLevel.net
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
     }
 }
 
@@ -69,10 +69,10 @@ public struct NetNode: TopNodeProtocol {
 public struct DebugNode: TopNodeProtocol {
     public typealias Child = Nodes.Debug
 
-    public let oid = OID.TopLevel.debug
+    public let _oid = OID.TopLevel.debug
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
     }
 }
 
@@ -80,10 +80,10 @@ public struct DebugNode: TopNodeProtocol {
 public struct HWNode: TopNodeProtocol {
     public typealias Child = Nodes.HW
 
-    public let oid = OID.TopLevel.hw
+    public let _oid = OID.TopLevel.hw
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
     }
 }
 
@@ -91,9 +91,9 @@ public struct HWNode: TopNodeProtocol {
 public struct MachDepNode: TopNodeProtocol {
     public typealias Child = Nodes.MachDep
 
-    public let oid = OID.TopLevel.machdep
+    public let _oid = OID.TopLevel.machdep
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
     }
 }

--- a/Sources/SwiftSysctl/Protocol/FieldProtocol.swift
+++ b/Sources/SwiftSysctl/Protocol/FieldProtocol.swift
@@ -12,6 +12,6 @@ public protocol FieldProtocol {
     associatedtype Value
     associatedtype OIDType: OIDProtocol
 
-    var oid: OIDType { get }
-    var name: String { get }
+    var _oid: OIDType { get }
+    var _name: String { get }
 }

--- a/Sources/SwiftSysctl/Protocol/NodeProtocol.swift
+++ b/Sources/SwiftSysctl/Protocol/NodeProtocol.swift
@@ -13,8 +13,8 @@ public protocol NodeProtocol {
     associatedtype Child: NodeCollection
     associatedtype OIDType: OIDProtocol
 
-    var oid: OIDType { get }
-    var name: String { get }
+    var _oid: OIDType { get }
+    var _name: String { get }
 }
 
 extension NodeProtocol {
@@ -23,8 +23,8 @@ extension NodeProtocol {
     ) -> ChainedNode<GrandChild> {
         let node = Child._shared[keyPath: keyPath]
         return .init(
-            parents: [oid],
-            oid: node.oid
+            parents: [_oid],
+            oid: node._oid
         )
     }
 
@@ -33,8 +33,8 @@ extension NodeProtocol {
     ) -> ChainedNameNode<GrandChild> {
         let node = Child._shared[keyPath: keyPath]
         return .init(
-            parents: [oid],
-            oid: node.oid
+            parents: [_oid],
+            oid: node._oid
         )
     }
 
@@ -43,8 +43,8 @@ extension NodeProtocol {
     ) -> ChainedNode<GrandChild> {
         let node = Child._shared[keyPath: keyPath]
         return .init(
-            parents: [oid] + node.parents,
-            oid: node.oid
+            parents: [_oid] + node._parents,
+            oid: node._oid
         )
     }
 
@@ -53,8 +53,8 @@ extension NodeProtocol {
     ) -> ChainedNameNode<GrandChild> {
         let node = Child._shared[keyPath: keyPath]
         return .init(
-            parents: [oid] + node.parents,
-            oid: node.oid
+            parents: [_oid] + node._parents,
+            oid: node._oid
         )
     }
 
@@ -62,8 +62,8 @@ extension NodeProtocol {
         dynamicMember keyPath: KeyPath<Child, LeafNode<Value>>
     ) -> Field<Value> {
         .init(
-            parents: [oid],
-            oid: Child._shared[keyPath: keyPath].oid
+            parents: [_oid],
+            oid: Child._shared[keyPath: keyPath]._oid
         )
     }
 
@@ -71,8 +71,8 @@ extension NodeProtocol {
         dynamicMember keyPath: KeyPath<Child, LeafNameNode<Value>>
     ) -> NameField<Value> {
         .init(
-            parents: [oid],
-            oid: Child._shared[keyPath: keyPath].oid
+            parents: [_oid],
+            oid: Child._shared[keyPath: keyPath]._oid
         )
     }
 
@@ -80,8 +80,8 @@ extension NodeProtocol {
         dynamicMember keyPath: KeyPath<Child, AnyNode>
     ) -> AnyField {
         .init(
-            parents: [oid],
-            oid: Child._shared[keyPath: keyPath].oid
+            parents: [_oid],
+            oid: Child._shared[keyPath: keyPath]._oid
         )
     }
 }
@@ -91,9 +91,9 @@ public protocol ChainedNodeProtocol {
     associatedtype Child: NodeCollection
     associatedtype OIDType: OIDProtocol
 
-    var parents: [any OIDProtocol] { get }
-    var oid: OIDType { get }
-    var name: String { get }
+    var _parents: [any OIDProtocol] { get }
+    var _oid: OIDType { get }
+    var _name: String { get }
 }
 
 extension ChainedNodeProtocol {
@@ -102,8 +102,8 @@ extension ChainedNodeProtocol {
     ) -> ChainedNode<GrandChild> {
         let node = Child._shared[keyPath: keyPath]
         return .init(
-            parents: parents + [oid],
-            oid: node.oid
+            parents: _parents + [_oid],
+            oid: node._oid
         )
     }
 
@@ -112,8 +112,8 @@ extension ChainedNodeProtocol {
     ) -> ChainedNameNode<GrandChild> {
         let node = Child._shared[keyPath: keyPath]
         return .init(
-            parents: parents + [oid],
-            oid: node.oid
+            parents: _parents + [_oid],
+            oid: node._oid
         )
     }
 
@@ -122,8 +122,8 @@ extension ChainedNodeProtocol {
     ) -> ChainedNode<GrandChild> {
         let node = Child._shared[keyPath: keyPath]
         return .init(
-            parents: parents + [oid] + node.parents,
-            oid: node.oid
+            parents: _parents + [_oid] + node._parents,
+            oid: node._oid
         )
     }
 
@@ -132,29 +132,29 @@ extension ChainedNodeProtocol {
     ) -> ChainedNameNode<GrandChild> {
         let node = Child._shared[keyPath: keyPath]
         return .init(
-            parents: parents + [oid] + node.parents,
-            oid: node.oid
+            parents: _parents + [_oid] + node._parents,
+            oid: node._oid
         )
     }
 
     public subscript<Value>(dynamicMember keyPath: KeyPath<Child, LeafNode<Value>>) -> Field<Value> {
         .init(
-            parents: parents + [oid],
-            oid: Child._shared[keyPath: keyPath].oid
+            parents: _parents + [_oid],
+            oid: Child._shared[keyPath: keyPath]._oid
         )
     }
 
     public subscript<Value>(dynamicMember keyPath: KeyPath<Child, LeafNameNode<Value>>) -> NameField<Value> {
         .init(
-            parents: parents + [oid],
-            oid: Child._shared[keyPath: keyPath].oid
+            parents: _parents + [_oid],
+            oid: Child._shared[keyPath: keyPath]._oid
         )
     }
 
     public subscript(dynamicMember keyPath: KeyPath<Child, AnyNode>) -> AnyField {
         .init(
-            parents: parents + [oid],
-            oid: Child._shared[keyPath: keyPath].oid
+            parents: _parents + [_oid],
+            oid: Child._shared[keyPath: keyPath]._oid
         )
     }
 }

--- a/Sources/SwiftSysctl/SwiftSysctl.swift
+++ b/Sources/SwiftSysctl/SwiftSysctl.swift
@@ -7,7 +7,7 @@ extension Sysctl {
     public static func sysctl<FieldType: FieldProtocol>(
         _ field: FieldType
     ) -> String? where FieldType.Value == String {
-        guard let data = sysctl(field.name) else { return nil }
+        guard let data = sysctl(field._name) else { return nil }
 
         return data.withUnsafeBytes {
             guard let baseAddress = $0.baseAddress else {
@@ -24,7 +24,7 @@ extension Sysctl {
     public static func sysctl<FieldType: FieldProtocol>(
         _ field: FieldType
     ) -> FieldType.Value? where FieldType.Value: FixedWidthInteger {
-        guard let data = sysctl(field.name) else { return nil }
+        guard let data = sysctl(field._name) else { return nil }
 
         return data.withUnsafeBytes { $0.load(as: FieldType.Value.self) }
     }
@@ -34,7 +34,7 @@ extension Sysctl {
     public static func sysctl<FieldType: FieldProtocol>(
         _ field: FieldType
     ) -> Data? {
-        sysctl(field.name)
+        sysctl(field._name)
     }
 }
 
@@ -47,11 +47,11 @@ extension Sysctl {
         var size = 0
         var ret: Int32 = 0
 
-        ret = sysctlnametomib(node.name, nil, &size)
+        ret = sysctlnametomib(node._name, nil, &size)
         guard ret == 0 else { return nil }
 
         var mib = [Int32](repeating: 0, count: size)
-        ret = sysctlnametomib(node.name, &mib, &size)
+        ret = sysctlnametomib(node._name, &mib, &size)
         guard ret == 0 else { return nil }
 
         mib += add
@@ -115,7 +115,7 @@ extension Sysctl {
     public static func kind<FieldType: FieldProtocol>(
         _ field: FieldType
     ) -> CtlKind?  {
-        guard let oid = _oid(field.name),
+        guard let oid = _oid(field._name),
               let fmt = _oidfmt(oid) else {
             return nil
         }
@@ -126,7 +126,7 @@ extension Sysctl {
     public static func format<FieldType: FieldProtocol>(
         _ field: FieldType
     ) -> String?  {
-        guard let oid = _oid(field.name),
+        guard let oid = _oid(field._name),
               let fmt = _oidfmt(oid) else {
             return nil
         }

--- a/Sources/SwiftSysctl/Util/Field.swift
+++ b/Sources/SwiftSysctl/Util/Field.swift
@@ -9,76 +9,94 @@
 import Foundation
 
 public struct LeafNode<Value>: FieldProtocol {
-    public let oid: OID
+    public let _oid: OID
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
+    }
+    
+    init(oid: OID) {
+        self._oid = oid
     }
 }
 
 public struct LeafNameNode<Value>: FieldProtocol {
-    public let oid: NameOID
+    public let _oid: NameOID
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
+    }
+    
+    init(oid: NameOID) {
+        self._oid = oid
     }
 }
 
 public struct Field<Value>: FieldProtocol {
-    public let parents: [any OIDProtocol]
-    public let oid: OID
+    public let _parents: [any OIDProtocol]
+    public let _oid: OID
 
-    public var name: String {
-        (parents + [oid]).map(\.name).joined(separator: ".")
+    public var _name: String {
+        (_parents + [_oid]).map(\.name).joined(separator: ".")
+    }
+    
+    init(parents: [any OIDProtocol], oid: OID) {
+        self._parents = parents
+        self._oid = oid
     }
 }
 
 public struct NameField<Value>: FieldProtocol {
-    public let parents: [any OIDProtocol]
-    public let oid: NameOID
+    public let _parents: [any OIDProtocol]
+    public let _oid: NameOID
 
-    public var name: String {
-        (parents + [oid]).map(\.name).joined(separator: ".")
+    public var _name: String {
+        (_parents + [_oid]).map(\.name).joined(separator: ".")
+    }
+    
+    init(parents: [any OIDProtocol], oid: NameOID) {
+        self._parents = parents
+        self._oid = oid
     }
 }
 
 public struct AnyNode {
-    public let oid: any OIDProtocol
+    public let _oid: any OIDProtocol
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
     }
 
     public init(oid: any OIDProtocol) {
-        self.oid = oid
+        self._oid = oid
     }
 
     public init<Child>(_ node: Node<Child>) {
-        self.init(oid: node.oid)
+        self.init(oid: node._oid)
     }
 
     public init<Child>(_ node: NameNode<Child>) {
-        self.init(oid: node.oid)
+        self.init(oid: node._oid)
     }
 }
 
 public struct AnyField {
-    public let parents: [any OIDProtocol]
-    public let oid: any OIDProtocol
+    public let _parents: [any OIDProtocol]
+    public let _oid: any OIDProtocol
 
-    public var name: String {
-        (parents + [oid]).map(\.name).joined(separator: ".")
+    public var _name: String {
+        (_parents + [_oid]).map(\.name).joined(separator: ".")
     }
 
     public init(parents: [any OIDProtocol], oid: any OIDProtocol) {
-        self.parents = parents
-        self.oid = oid
+        self._parents = parents
+        self._oid = oid
     }
 
     public init<Child>(_ node: ChainedNode<Child>) {
         self.init(
-            parents: node.parents,
-            oid: node.oid
+            parents: node._parents,
+            oid: node._oid
         )
     }
 }

--- a/Sources/SwiftSysctl/Util/Node.swift
+++ b/Sources/SwiftSysctl/Util/Node.swift
@@ -11,40 +11,58 @@ import Foundation
 // MARK: - Node
 @dynamicMemberLookup
 public struct Node<Child: NodeCollection>: NodeProtocol {
-    public let oid: OID
+    public let _oid: OID
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
+    }
+    
+    init(oid: OID) {
+        self._oid = oid
     }
 }
 
 @dynamicMemberLookup
 public struct NameNode<Child: NodeCollection>: NodeProtocol {
-    public let oid: NameOID
+    public let _oid: NameOID
 
-    public var name: String {
-        oid.name
+    public var _name: String {
+        _oid.name
+    }
+    
+    init(oid: NameOID) {
+        self._oid = oid
     }
 }
 
 // MARK: Chained
 @dynamicMemberLookup
 public struct ChainedNode<Child: NodeCollection>: ChainedNodeProtocol {
-    public let parents: [any OIDProtocol]
-    public let oid: OID
+    public let _parents: [any OIDProtocol]
+    public let _oid: OID
 
-    public var name: String {
-        (parents + [oid]).map(\.name).joined(separator: ".")
+    public var _name: String {
+        (_parents + [_oid]).map(\.name).joined(separator: ".")
+    }
+    
+    init(parents: [any OIDProtocol], oid: OID) {
+        self._parents = parents
+        self._oid = oid
     }
 }
 
 @dynamicMemberLookup
 public struct ChainedNameNode<Child: NodeCollection>: ChainedNodeProtocol {
-    public let parents: [any OIDProtocol]
-    public let oid: NameOID
+    public let _parents: [any OIDProtocol]
+    public let _oid: NameOID
 
-    public var name: String {
-        (parents + [oid]).map(\.name).joined(separator: ".")
+    public var _name: String {
+        (_parents + [_oid]).map(\.name).joined(separator: ".")
+    }
+    
+    init(parents: [any OIDProtocol], oid: NameOID) {
+        self._parents = parents
+        self._oid = oid
     }
 }
 


### PR DESCRIPTION
Sometimes the name of the Node element was overlaid with the name of the element in the Node.